### PR TITLE
fix: rely on findmnt command instead of ansible_mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # filesystems
 
-## 1.0.1
+## [1.0.1] 2020-02-01
 
 * fix: rely on findmnt command instead of ansible_mounts facts
 * use findmnt to get the current mount order

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # filesystems
 
+## 1.0.1
+
+* fix: rely on findmnt command instead of ansible_mounts facts
+* use findmnt to get the current mount order
+* move assertions about nested/hidden mounts into a dedicated tasks file
+* bump min ansible version to >= 2.8, so use `quiet` for assert tasks
+
 ## 0.3.0
 
 * Refactor `serial` and `sequential` to simplify the code (remove `action.yml`,

--- a/tasks/assertions.yml
+++ b/tasks/assertions.yml
@@ -19,7 +19,8 @@
     that:
       - ( ansible_os_family in ['Debian'] and ansible_distribution_version is version('9.0', '>=') ) or
         ( ansible_os_family in ['RedHat'] and ansible_distribution_version is version('7.0', '>=') )
-      - ansible_version.full is version('2.7', '>=')
+      - ansible_version.full is version('2.8', '>=')
+    quiet: yes
 
 
 ################################################################################
@@ -67,8 +68,8 @@
       - fstab_devicelinks is undefined
       - fstab_filesystems is undefined
       - fstab_mountpoints is undefined
-      - actual_ansible_mounts is undefined
-      - wanted_ansible_mounts is undefined
+      - actual_mounts is undefined
+      - wanted_mounts is undefined
       - fs_canonical is undefined
       - fs_ismounted is undefined
       - fs_submounts is undefined
@@ -81,193 +82,70 @@
       - _fs_item is undefined
       - fstab_item is undefined
 
+    quiet: yes
+
 
 ################################################################################
 #
-- name: "share variables in a block"
-  block:
+- name: "validate filesystems__fslist dictionary keys (types, formats, values)"
+  assert:
+    that:
+      # Check mandatory variables and their format/type for all dicts of the
+      # list.
+      - _fs_item | type_debug in ['dict']
 
-    - name: "validate filesystems__fslist dictionary keys (types, formats, values)"
-      assert:
-        that:
-          # Check mandatory variables and their format/type for all dicts of the
-          # list.
-          - _fs_item | type_debug in ['dict']
+      # No first level directory, supports trailing / or consecutive /, since
+      # this will be normalized before doing anything - except overwrite the
+      # file /etc/fstab, that will be done first for the same reason
+      - _fs_item.path is defined
+      - _fs_item.path is regex('^(/+[^/ ]+){2,}/?$')
+      - _fs_item.path is not regex('/\.\.?/')
 
-          # No first level directory, supports trailing / or consecutive /, since
-          # this will be normalized before doing anything - except overwrite the
-          # file /etc/fstab, that will be done first for the same reason
-          - _fs_item.path is defined
-          - _fs_item.path is regex('^(/+[^/ ]+){2,}/?$')
-          - _fs_item.path is not regex('/\.\.?/')
+      # This is the LV name, not the path of the device (nor a symlink to
+      # it). We accept everything is supported by LVM. Dashes (-), that need
+      # to be translated to double-dashes (--) to match the device-mapper
+      # naming format, are supported too, as in (with lv='lv-foo-bar')
+      # /dev/vg-00/lv-foo-bar  <==>  /dev/mapper/vg--00-lv--foo--bar
+      - _fs_item.lv is defined or fs_ismounted | bool
+      - _fs_item.lv is undefined or _fs_item.lv is regex('^[^/]+$')
 
-          # This is the LV name, not the path of the device (nor a symlink to
-          # it). We accept everything is supported by LVM. Dashes (-), that need
-          # to be translated to double-dashes (--) to match the device-mapper
-          # naming format, are supported too, as in (with lv='lv-foo-bar')
-          # /dev/vg-00/lv-foo-bar  <==>  /dev/mapper/vg--00-lv--foo--bar
-          - _fs_item.lv is defined or fs_ismounted | bool
-          - _fs_item.lv is undefined or _fs_item.lv is regex('^[^/]+$')
+      # The VG exists
+      - _fs_item.vg is undefined or _fs_item.vg in ansible_lvm.vgs
+      - _fs_item.vg is defined or filesystems__default_vg in ansible_lvm.vgs
 
-          # The VG exists
-          - _fs_item.vg is undefined or _fs_item.vg in ansible_lvm.vgs
-          - _fs_item.vg is defined or filesystems__default_vg in ansible_lvm.vgs
+      # The filesystem type, the volume size or the mount options don't
+      # matter when unmounting/removing a LV. This is why these keys have
+      # default values.
+      # Accepted size formats:
+      # - Amounts are integers
+      # - Absolute units are k, m, g and t, case insensitive:
+      #   1k = 1K = 1024 bytes (B)
+      #   1m = 1M = 1024K
+      #   ...
+      # - Percent units are relative to VG size (%VG) and VG free size
+      #   (%FREE).
+      # - With percent units, amounts are in the range 1-100.
+      # - All above formats can be prefixed by either +, - or nothing.
+      #
+      - _fs_item.size is undefined or
+        _fs_item.size is regex('^[+-]?([1-9][0-9]*[BkKmMgGtT]|([1-9][0-9]?|100)%(VG|FREE|PVS))$')
+      - _fs_item.size is defined or
+        filesystems__default_size is regex('^[+-]?([1-9][0-9]*[BkKmMgGtT]|([1-9][0-9]?|100)%(VG|FREE|PVS))$')
 
-          # The filesystem type, the volume size or the mount options don't
-          # matter when unmounting/removing a LV. This is why these keys have
-          # default values.
-          # Accepted size formats:
-          # - Amounts are integers
-          # - Absolute units are k, m, g and t, case insensitive:
-          #   1k = 1K = 1024 bytes (B)
-          #   1m = 1M = 1024K
-          #   ...
-          # - Percent units are relative to VG size (%VG) and VG free size
-          #   (%FREE).
-          # - With percent units, amounts are in the range 1-100.
-          # - All above formats can be prefixed by either +, - or nothing.
-          #
-          - _fs_item.size is undefined or
-            _fs_item.size is regex('^[+-]?([1-9][0-9]*[BkKmMgGtT]|([1-9][0-9]?|100)%(VG|FREE|PVS))$')
-          - _fs_item.size is defined or
-            filesystems__default_size is regex('^[+-]?([1-9][0-9]*[BkKmMgGtT]|([1-9][0-9]?|100)%(VG|FREE|PVS))$')
+      - _fs_item.fstype is undefined or _fs_item.fstype in ['ext4', 'xfs']
+      - _fs_item.fstype is defined or filesystems__default_fstype in ['ext4', 'xfs']
 
-          - _fs_item.fstype is undefined or _fs_item.fstype in ['ext4', 'xfs']
-          - _fs_item.fstype is defined or filesystems__default_fstype in ['ext4', 'xfs']
+      # Exhaustivity is not a goal on its own. This is just a kind of example
+      # of checking optional parameters. Think if you really want to check
+      # permission values in octal as well as litteral formats for every case
+      # encountered...
+      - _fs_item.passno is undefined or _fs_item.passno in [0, 2, '0', '2']
+      - _fs_item.passno is defined or filesystems__default_passno | d(0) in [0, 2, '0', '2']
 
-          # Exhaustivity is not a goal on its own. This is just a kind of example
-          # of checking optional parameters. Think if you really want to check
-          # permission values in octal as well as litteral formats for every case
-          # encountered...
-          - _fs_item.passno is undefined or _fs_item.passno in [0, 2, '0', '2']
-          - _fs_item.passno is defined or filesystems__default_passno | d(0) in [0, 2, '0', '2']
+    quiet: yes
+    fail_msg: "Item {{ _fs_item }} is missing a mandatory key or its format is invalid.
+      Please read documentation and fix the item before moving forward."
 
-        fail_msg: "Item {{ _fs_item }} is missing a mandatory key or its format is invalid.
-          Please read documentation and fix the item before moving forward."
-      loop: "{{ filesystems__fslist }}"
-      loop_control:
-        loop_var: _fs_item
-
-
-    ################################################################################
-    #
-    - name: "validate requested state is reachable regarding possible troubles with nested or hidden mounts"
-      assert:
-        that:
-          # There is probably no chance to cleanly setup a new mountpoint if an
-          # existing one would be a subdirectory of the new one, i.e. if nested
-          # mounts are not set in the proper order.
-          # For example:
-          #   /var/projects/apa_nna/apache_2.4 is an active mountpoint
-          #   /var/projects is to be set as a mountpoint
-          # In this example, the mount on /var/projects will hide the one that
-          # is already set on /var/projects/apa_nna/apache_2.4, and this is not
-          # what we want !
-          #
-          # Other example:
-          #   /var/projects/apa_nna/apache_2.4 is an hidden mountpoint
-          #   /var/projects is the active mountpoint hiding the previous
-          # The only one thing we are able to do is to unmount or remove the
-          # hiding mountpoint to free the hidden one. Do not ever try to unset
-          # the hidden mount at the same time, since the role will sort them in
-          # reverse order for unmount operations.
-          #
-          # This piece of code is aware of that, and takes care to:
-          #   - not fail if the wanted mount is active and role's state=present,
-          #     unless this active mount is hidding another one.
-          #   - not fail if the mount is not set and role's state=absent/unmounted
-          #   - not fail if the mount is set, role's state=absent and submounts
-          #     are listed to be unset too, unless they're already mounted and
-          #     hidden by the mount to unset. Yes.
-          #
-          - fs_hidden_by == []
-
-          - ( fs_submounts == [] ) or
-            ( filesystems__state in ['present'] and fs_ismounted | bool and fs_subhidden == [] ) or
-            ( filesystems__state in ['absent','unmounted'] and not fs_ismounted | bool ) or
-            ( filesystems__state in ['absent','unmounted'] and
-              fs_subnested | difference(fs_subwanted) == [] and
-              fs_subhidden | difference(fs_subwanted) == fs_subhidden )
-
-        fail_msg: "You attempt to
-          {{ 'enable' if filesystems__state == 'present' else 'disable' }}
-          a mountpoint on {{ fs_canonical }}, but it seems there is some
-          trouble with that.
-
-          {%- if fs_hidden_by != [] %}
-          {{ fs_canonical }} is currently mounted but hidden by a mount over
-          {{ fs_hidden_by | join(' and ') }}. Absolutely nothing can be done or
-          undone with {{ fs_canonical }} while it's still overmounted. Please
-          unmount {{ fs_hidden_by | join(' and ') }} before moving forward.
-
-          {%- elif filesystems__state in ['present'] and fs_ismounted | bool %}
-          {{ fs_subhidden | join(' and ') }}
-          {{ 'are' if fs_subhidden | length > 1 else 'is' }} currently mounted
-          but hidden by the mount over {{ fs_canonical }}. Please unmount
-          {{ fs_canonical }} before moving forward.
-
-          {%- elif filesystems__state in ['present'] %}
-          Mounting a filesystem on {{ fs_canonical }} would hide currently
-          active mount {{ fs_submounts | join(' and ') }}. Nobody wants this.
-          Please unmount {{ fs_submounts | join(' and ') }} before moving
-          forward.
-
-          {%- else %}
-          {%- if fs_subnested | difference(fs_subwanted) != [] %}
-          {{ fs_subnested | difference(fs_subwanted) | join(' and ') }} is a
-          nested mountpoint that needs to be unmounted either before or in
-          the same move than {{ fs_canonical }}. Please unmount
-          {{ fs_subnested | join(' and ') }} before moving forward.
-          {%- endif %}
-          {%- if fs_subhidden | difference(fs_subwanted) != fs_subhidden %}
-          {{ fs_subhidden | intersect(fs_subwanted) | join(' and ') }} is
-          currently mounted and hidden by the mount on {{ fs_canonical }},
-          and can't be disabled in the same move. Please unmount
-          {{ fs_canonical }} before moving forward.
-          {%- endif %}
-          {%- endif %}"
-
-      loop: "{{ filesystems__fslist }}"
-      loop_control:
-        loop_var: _fs_item
-        label:
-          path: "{{ _fs_item.path }}"
-
-  vars:
-    actual_ansible_mounts: |
-      [{% for x in ansible_mounts %}"{{ x.mount }}",{% endfor %} ]
-    wanted_ansible_mounts: |
-      [ {% for x in filesystems__fslist %}"{{ x.path | regex_replace('/+', '/') | regex_replace('/$', '') }}",{% endfor %} ]
-
-    # Canonical path of the mountpoint
-    fs_canonical: "{{ _fs_item.path | regex_replace('/+', '/') | regex_replace('/$', '') }}"
-    # If it is mounted or not
-    fs_ismounted: "{{ fs_canonical in actual_ansible_mounts }}"
-    # The mounts wanted by the user (to be set or unset or unmounted)
-    fs_subwanted: "{{ wanted_ansible_mounts | select('search', '^%s/.*' % fs_canonical) | list }}"
-    # Submounts (nested + hidden) of current FS
-    fs_submounts: "{{ actual_ansible_mounts | select('search', '^%s/.*' % fs_canonical) | list }}"
-
-    # Nested mounts (submounts that are at the right place) of current FS
-    fs_subnested: |
-      [
-        {% for x in ansible_mounts %}{% set i = loop.index - 1 %}{% if x.mount == fs_canonical %}
-        {% for m in ansible_mounts[i:] | json_query('[*].mount') if m is match('%s/' % x.mount) %}
-        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
-      ]
-
-    # Hidden mounts (submounts that are at the wrong place) of current FS
-    fs_subhidden: |
-      [
-        {% for x in ansible_mounts %}{% set i = loop.index - 1 %}{% if x.mount == fs_canonical %}
-        {% for m in ansible_mounts[:i] | json_query('[*].mount') if m is match('%s/' % x.mount) %}
-        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
-      ]
-
-    # The parent mount that became an overmount and hides the current mount (hopefully none)
-    fs_hidden_by: |
-      [
-        {% for x in ansible_mounts %}{% set i = loop.index - 1 %}{% if x.mount == fs_canonical %}
-        {% for m in ansible_mounts[i:] | json_query('[*].mount') if x.mount is match('%s/' % m) %}
-        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
-      ]
+  loop: "{{ filesystems__fslist }}"
+  loop_control:
+    loop_var: _fs_item

--- a/tasks/check-mount-orders.yml
+++ b/tasks/check-mount-orders.yml
@@ -1,0 +1,127 @@
+---
+# role: filesystems
+# file: tasks/check-mount-orders.yml
+
+
+# There is probably no chance to cleanly setup a new mountpoint if an
+# existing one would be a subdirectory of the new one, i.e. if nested
+# mounts are not set in the proper order.
+# For example:
+#   /var/projects/apa_nna/apache_2.4 is an active mountpoint
+#   /var/projects is to be set as a mountpoint
+# In this example, the mount on /var/projects will hide the one that
+# is already set on /var/projects/apa_nna/apache_2.4, and this is not
+# what we want !
+#
+# Other example:
+#   /var/projects/apa_nna/apache_2.4 is an hidden mountpoint
+#   /var/projects is the active mountpoint hiding the previous
+# The only one thing we are able to do is to unmount or remove the
+# hiding mountpoint to free the hidden one. Do not ever try to unset
+# the hidden mount at the same time, since the role will sort them in
+# reverse order for unmount operations.
+#
+# This piece of code is aware of that, and takes care to:
+#   - not fail if the wanted mount is active and role's state=present,
+#     unless this active mount is hidding another one.
+#   - not fail if the mount is not set and role's state=absent/unmounted
+#   - not fail if the mount is set, role's state=absent and submounts
+#     are listed to be unset too, unless they're already mounted and
+#     hidden by the mount to unset. Yes.
+
+
+- name: "get directories mount order with 'findmnt'"
+  command: findmnt --df --noheadings --notruncate --output target
+  register: filesystems__findmnt_command
+  changed_when: false
+  check_mode: false
+
+
+- name: "validate requested state is reachable regarding possible troubles with nested or hidden mounts"
+  assert:
+    that:
+      - fs_hidden_by == []
+      - ( fs_submounts == [] ) or
+        ( filesystems__state in ['present'] and fs_ismounted | bool and fs_subhidden == [] ) or
+        ( filesystems__state in ['absent','unmounted'] and not fs_ismounted | bool ) or
+        ( filesystems__state in ['absent','unmounted'] and
+          fs_subnested | difference(fs_subwanted) == [] and
+          fs_subhidden | difference(fs_subwanted) == fs_subhidden )
+    quiet: yes
+    fail_msg: "You attempt to
+      {{ 'enable' if filesystems__state == 'present' else 'disable' }}
+      a mountpoint on {{ fs_canonical }}, but it seems there is some
+      trouble with that.
+
+      {%- if fs_hidden_by != [] %}
+      {{ fs_canonical }} is currently mounted but hidden by a mount over
+      {{ fs_hidden_by | join(' and ') }}. Absolutely nothing can be done or
+      undone with {{ fs_canonical }} while it's still overmounted. Please
+      unmount {{ fs_hidden_by | join(' and ') }} before moving forward.
+
+      {%- elif filesystems__state in ['present'] and fs_ismounted | bool %}
+      {{ fs_subhidden | join(' and ') }}
+      {{ 'are' if fs_subhidden | length > 1 else 'is' }} currently mounted
+      but hidden by the mount over {{ fs_canonical }}. Please unmount
+      {{ fs_canonical }} before moving forward.
+
+      {%- elif filesystems__state in ['present'] %}
+      Mounting a filesystem on {{ fs_canonical }} would hide currently
+      active mount {{ fs_submounts | join(' and ') }}. Nobody wants this.
+      Please unmount {{ fs_submounts | join(' and ') }} before moving
+      forward.
+
+      {%- else %}
+      {%- if fs_subnested | difference(fs_subwanted) != [] %}
+      {{ fs_subnested | difference(fs_subwanted) | join(' and ') }} is a
+      nested mountpoint that needs to be unmounted either before or in
+      the same move than {{ fs_canonical }}. Please unmount
+      {{ fs_subnested | join(' and ') }} before moving forward.
+      {%- endif %}
+      {%- if fs_subhidden | difference(fs_subwanted) != fs_subhidden %}
+      {{ fs_subhidden | intersect(fs_subwanted) | join(' and ') }} is
+      currently mounted and hidden by the mount on {{ fs_canonical }},
+      and can't be disabled in the same move. Please unmount
+      {{ fs_canonical }} before moving forward.
+      {%- endif %}
+      {%- endif %}"
+
+  loop: "{{ filesystems__fslist }}"
+  loop_control:
+    loop_var: _fs_item
+    label:
+      path: "{{ _fs_item.path }}"
+
+  vars:
+    actual_mounts: "{{ filesystems__findmnt_command.stdout_lines | intersect(ansible_mounts | json_query('[*].mount')) }}"
+    wanted_mounts: |
+      [ {% for x in filesystems__fslist %}"{{ x.path | regex_replace('/+', '/') | regex_replace('/$', '') }}",{% endfor %} ]
+    # Canonical path of the mountpoint
+    fs_canonical: "{{ _fs_item.path | regex_replace('/+', '/') | regex_replace('/$', '') }}"
+    # If it is mounted or not
+    fs_ismounted: "{{ fs_canonical in actual_mounts }}"
+    # The mounts wanted by the user (to be set or unset or unmounted)
+    fs_subwanted: "{{ wanted_mounts | select('search', '^%s/.*' % fs_canonical) | list }}"
+    # Submounts (nested + hidden) of current FS
+    fs_submounts: "{{ actual_mounts | select('search', '^%s/.*' % fs_canonical) | list }}"
+    # Nested mounts (submounts that are at the right place) of current FS
+    fs_subnested: |
+      [
+        {% for x in actual_mounts %}{% set i = loop.index - 1 %}{% if x == fs_canonical %}
+        {% for m in actual_mounts[i:] if m is match('%s/' % x) %}
+        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
+      ]
+    # Hidden mounts (submounts that are at the wrong place) of current FS
+    fs_subhidden: |
+      [
+        {% for x in actual_mounts %}{% set i = loop.index - 1 %}{% if x == fs_canonical %}
+        {% for m in actual_mounts[:i] if m is match('%s/' % x) %}
+        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
+      ]
+    # The parent mount that became an overmount and hides the current mount (hopefully none)
+    fs_hidden_by: |
+      [
+        {% for x in actual_mounts %}{% set i = loop.index - 1 %}{% if x == fs_canonical %}
+        {% for m in actual_mounts[i:] if x is match('%s/' % m) %}
+        "{{ m }}",{% endfor %}{% endif %}{% endfor %}
+      ]

--- a/tasks/cross-facts.yml
+++ b/tasks/cross-facts.yml
@@ -54,7 +54,7 @@
     __tempvar2__: |
       [
         {% for p in __tempvar0__ | product(__tempvar1__) if
-          p.0 != p.1 and p.0.fstype == p.1.fstype and ( p.0.dir == p.1.dir or p.0.dev == p.1.dev ) %}{
+          p.0 != p.1 and p.0.fstype == p.1.fstype and p.0.dir != "" and ( p.0.dir == p.1.dir or p.0.dev == p.1.dev ) %}{
           "fstype": "{{ p.0.fstype }}",
           "new": { "dev": "{{ p.1.dev }}", "dir": "{{ p.1.dir }}" },
           "old": { "dev": "{{ p.0.dev }}", "dir": "{{ p.0.dir }}" },

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,6 @@
 #   device !
 #
 - import_tasks: normalize-fstab.yml
-  check_mode: true
 
 
 ################################################################################
@@ -54,11 +53,21 @@
   changed_when: false
   check_mode: false
 
-- name: "get relevant info about mounted devices"
+- name: "get relevant info about mounted devices with 'lsblk'"
   command: lsblk --output fstype,mountpoint,path --json
   register: filesystems__lsblk_command
   changed_when: false
   check_mode: false
+
+
+################################################################################
+# CHECK TOPOLOGY
+#
+# Check whether the wanted topology is reachable or not. Cases of error are
+# inconsistencies in the directories mount order, as when a directory is mounted
+# over an active mount on its subdirectory.
+#
+- import_tasks: check-mount-orders.yml
 
 
 

--- a/tasks/rename.yml
+++ b/tasks/rename.yml
@@ -71,6 +71,7 @@
           | select('search', '^%s/' % _fs_item.old.dir)
           | list | sort
         )
+    quiet: yes
     fail_msg: "You attempt to {{ 'rename device' if _fs_item.type == 'dev' else 'move location of' }} \
       {{ _fs_item.source }} to {{ _fs_item.target }}. {{ _fs_item.old.dir }} needs to be unmounted \
       to free {{ 'it' if _fs_item.type == 'dir' else 'its device %s' % _fs_item.source }} for renaming. \
@@ -108,6 +109,7 @@
       - _fs_item.target not in ansible_mounts | json_query('[*].mount')
       - not _fs_rename_stat_.results[_fs_index].stat.exists or
         ( _fs_rename_stat_.results[_fs_index].stat.isdir and _fs_rename_stat_.results[_fs_index].stat.nlink == 2 )
+    quiet: yes
     fail_msg: "You attempt to move location of {{ _fs_item.source }} to {{ _fs_item.target }}, which \
       {{ 'is already an active mountpoint' if _fs_item.target in ansible_mounts | json_query('[*].mount')
       else 'is not an empty directory' }}. Maybe something is wrong with your setup, or something needs \

--- a/tasks/validate-fstab.yml
+++ b/tasks/validate-fstab.yml
@@ -35,6 +35,7 @@
     - name: "track duplicates, unpredictable names and bad fstypes in /etc/fstab"
       assert:
         that: "{{ fstab_assertions_for_python2 | d(fstab_assertions) }}"
+        quiet: yes
 
 
     - name: "check that devices and mountpoints recorded in /etc/fstab exist"


### PR DESCRIPTION
* use findmnt to get the current mount order
* move assertions about nested/hidden mounts into a dedicated tasks file
* bump ansible version to >= 2.8, so use `quiet` for assert tasks
* filter missing values in crossed facts